### PR TITLE
fix: cacheOtherProvider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,7 @@ provider
       Object.keys(finalProvider).forEach((key) => {
         window.ethereum[key] = (finalProvider as EthereumProvider)[key];
       });
-      const keys = ["selectedAddress", "chainId", 'networkVersion'];
+      const keys = ["selectedAddress", "chainId", "networkVersion"];
       keys.forEach((key) => {
         Object.defineProperty(cacheOtherProvider, key, {
           get() {
@@ -375,6 +375,9 @@ window.ethereum = rabbyProvider;
 
 Object.defineProperty(window, "ethereum", {
   set(val) {
+    if (val?.isRabby) {
+      return;
+    }
     provider.requestInternalMethods({
       method: "hasOtherProvider",
       params: [],


### PR DESCRIPTION
Some dapps may set `window.ethereum = window.ethereum` before get the `isDefaultWallet()` result.

eg: https://daomaker.com/